### PR TITLE
Added a link to the sourcecode for the Apple DTK

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ Download the files as a zip using the green button, or clone the repository to y
 
 Release v1.0 corresponds to the code in the published book, without corrections or updates.
 
+## Adaptation for Apple ARM64
+
+An adaptation of the sourcecode for the Apple ARM64 Prototype can be found here: https://github.com/below/HelloSilicon
+
 ## Contributions
 
 See the file Contributing.md for more information on how you can contribute to this repository.


### PR DESCRIPTION
I have added a link to my repository, where I have adapted all source code in the book for the Apple ARM64 prototype